### PR TITLE
add preinstall step in order to run prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "precommit": "npm run lint -s",
     "prefast-test": "npm run prepublish",
     "prepublish": "npm run build",
+    "preinstall": "npm run prepublish",
     "test": "NODE_ENV=test npm run lint && npm run fast-test",
     "view-cover": "npm run cover -- --report=html && opn ./coverage/index.html"
   }


### PR DESCRIPTION
When installing with NPM via a github URL, the prepublish hook is not run: https://github.com/npm/npm/issues/3055. The workaround for this is to add a preinstall step that in turn calls the prepublish step.